### PR TITLE
Fix deadlock on process termination

### DIFF
--- a/rhasspy3/program.py
+++ b/rhasspy3/program.py
@@ -32,7 +32,7 @@ class ProcessContextManager:
         try:
             if self.proc.returncode is None:
                 self.proc.terminate()
-                await self.proc.wait()
+                await self.proc.communicate()
         except ProcessLookupError:
             # Expected when process has already exited
             pass


### PR DESCRIPTION
Fixes #29

From the [asyncio.subprocess.wait specification](https://docs.python.org/3/library/asyncio-subprocess.html#asyncio.subprocess.Process.wait):

> **Note**: This method can deadlock when using `stdout=PIPE` or `stderr=PIPE` and the child process generates so much output that it blocks waiting for the OS pipe buffer to accept more data. Use the [communicate()](https://docs.python.org/3/library/asyncio-subprocess.html#asyncio.subprocess.Process.communicate) method when using pipes to avoid this condition.

This is exactly what we are doing.
1. Start the process with `stdout=PIPE`
2. Example for the `mic` program: read from the process until ASR is done
3. Signal the process to stop and wait till it finishes

If between 2 and 3 the process outputs more data (as mic continues to record the sound), it creates a deadlock: we wait for the process to finish and the process waits for us to read the data he had already sent us.
This PR fixes that race condition as recommended in the documentation, by using `communicate()`, which will read all the data and then wait for the process to terminate.